### PR TITLE
Fix typo Recruit name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Respuit
-馬鹿野郎お前俺はreqruitのAPI使うぞお前
+馬鹿野郎お前俺はRecruitのAPI使うぞお前
 
 # Use Teck
 - python(3.5)


### PR DESCRIPTION
## What

* `requit` -> `recruit`

## Why

* Because it is a typo